### PR TITLE
Refactor document handling

### DIFF
--- a/src/dialog.html
+++ b/src/dialog.html
@@ -5,7 +5,7 @@
   <input id="submit" type="submit" value="Import" />
 </form>
 <script>
-  document.getElementById('form').addEventListener('submit', function (e) {
+  function handleSubmit(e) {
     e.preventDefault();
     const button = document.getElementById('submit');
     button.disabled = true;
@@ -13,6 +13,7 @@
     const file = fileInput.files[0];
     if (!file) {
       alert('Please select a file');
+      button.disabled = false;
       return;
     }
     const reader = new FileReader();
@@ -25,5 +26,6 @@
         .addReportToDoc(content);
     };
     reader.readAsText(file);
-  });
+  }
+  document.getElementById('form').addEventListener('submit', handleSubmit);
 </script>

--- a/src/docBuilder.ts
+++ b/src/docBuilder.ts
@@ -1,0 +1,59 @@
+export class DocumentBuilder {
+  public requests: GoogleAppsScript.Docs.Schema.Request[] = [];
+  private index = 1;
+
+  insertText(text: string) {
+    this.requests.push({
+      insertText: { location: { index: this.index }, text: `${text}\n` },
+    });
+    this.index += text.length + 1;
+  }
+
+  insertBoldText(text: string) {
+    this.requests.push({
+      insertText: { location: { index: this.index }, text: `${text}\n` },
+    });
+    this.requests.push({
+      updateTextStyle: {
+        range: {
+          startIndex: this.index,
+          endIndex: this.index + text.length + 1,
+        },
+        textStyle: { bold: true },
+        fields: 'bold',
+      },
+    });
+    this.index += text.length + 1;
+  }
+
+  addHeading(text: string) {
+    const startIndex = this.index;
+    this.insertText(text);
+    this.requests.push({
+      updateParagraphStyle: {
+        range: { startIndex, endIndex: this.index },
+        paragraphStyle: { namedStyleType: 'HEADING_1' },
+        fields: 'namedStyleType',
+      },
+    });
+    this.requests.push({
+      updateTextStyle: {
+        range: { startIndex, endIndex: this.index },
+        textStyle: { bold: true, fontSize: { magnitude: 11, unit: 'PT' } },
+        fields: 'bold,fontSize',
+      },
+    });
+  }
+
+  createBullets(text: string) {
+    const startIndex = this.index;
+    this.insertText(text);
+    this.index = startIndex + text.replace(/^\t*/gm, '').length + 1;
+    this.requests.push({
+      createParagraphBullets: {
+        range: { startIndex, endIndex: this.index },
+        bulletPreset: 'BULLET_DISC_CIRCLE_SQUARE',
+      },
+    });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,57 @@
+export interface ReportMetadata {
+  generated_on?: string;
+  container_tool?: string;
+  title?: string;
+  description?: string;
+}
+
+export interface CopyFile {
+  src: string;
+  dest: string;
+}
+
+export interface Prepare {
+  commands?: string[];
+  copy_files?: CopyFile[];
+}
+
+export interface MainOperation {
+  commands?: string[];
+}
+
+export interface Definitions {
+  base_image?: string;
+  prepare?: Prepare;
+  main_operation?: MainOperation;
+  target_dirs?: string[];
+  exclude_paths?: string[];
+  omit_diff_paths?: string[];
+  command_diff?: { command: string; outfile: string }[];
+}
+
+export interface OperationResult {
+  command: string;
+  stdout: string;
+  stderr: string;
+  return_code: number;
+}
+
+export interface CommandOutput {
+  command: string;
+  diff_file: string;
+  diff_content: string;
+}
+
+export interface DiffReports {
+  filesystem_rq?: string[];
+  filesystem_urN?: string[];
+  command_outputs?: CommandOutput[];
+}
+
+export interface EnvDiffReport {
+  report_metadata?: ReportMetadata;
+  definitions?: Definitions;
+  main_operation_results?: OperationResult[];
+  diff_reports?: DiffReports;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary
- extract typing information into new `types.ts`
- add `DocumentBuilder` helper class
- refactor `addReportToDoc` to use the new builder
- tidy up HTML form script

## Testing
- `npm run lint`
- `npm run format`
- `npm run test`
